### PR TITLE
Enhance momtaz_get_settings()

### DIFF
--- a/momtaz/includes/settings.php
+++ b/momtaz/includes/settings.php
@@ -25,7 +25,7 @@ function momtaz_get_settings(){
 		// Get the option and cache it.
 		$momtaz->settings = get_option(
 				momtaz_theme_settings_option(),
-				momtaz_default_theme_settings()
+				array()
 			);
 			
 		// Append the default values of the unsaved settings.


### PR DESCRIPTION
Edit momtaz_get_settings() to make it able to get the default values of the unsaved theme settings.
