### PR TITLE
Use uasort() instead of usort() to order the stacks list.

### DIFF
--- a/momtaz/includes/stacks.php
+++ b/momtaz/includes/stacks.php
@@ -94,7 +94,7 @@ final class Momtaz_Stacks {
 
 		self::$stacks[ $id ] = $stack;
 
-		usort( self::$stacks, function( $a, $b ) {
+		uasort( self::$stacks, function( $a, $b ) {
 
 			$p1 = (int) $a->priority;
 			$p2 = (int) $b->priority;


### PR DESCRIPTION
changing usort to uasort to keep $stacks array keys intact.
